### PR TITLE
解决loading过程中的一个bug

### DIFF
--- a/lib/src/main/java/com/shadev/easyloadingdemo/view/LoadingButton.java
+++ b/lib/src/main/java/com/shadev/easyloadingdemo/view/LoadingButton.java
@@ -94,7 +94,6 @@ public class LoadingButton extends View{
 
                     @Override
                     public void onAnimationEnd(Animation animation) {
-                        isDefaultDraw = false;
                         isShowArc = true;
                         invalidate();
                         ScaleAnimation scaleAnimation = new ScaleAnimation(0f,1f,0f,1f, Animation.RELATIVE_TO_SELF,0.5f,Animation.RELATIVE_TO_SELF,0.5f);
@@ -109,7 +108,8 @@ public class LoadingButton extends View{
                             }
 
                         });
-                        LoadingButton.this.startAnimation(scaleAnimation);
+                        if(isDefaultDraw) LoadingButton.this.startAnimation(scaleAnimation);
+                        isDefaultDraw = false;
 
                     }
 
@@ -118,7 +118,7 @@ public class LoadingButton extends View{
 
                     }
                 });
-                LoadingButton.this.startAnimation(scaleAnimation);
+                if(isDefaultDraw) LoadingButton.this.startAnimation(scaleAnimation);
             }
         });
     }


### PR DESCRIPTION
loading 过程中，当不停的点击LodingBtn，scale动画会不停的演示。demo中，点击了'增加进度'后，在loading没有结束前再次点击LodingBtn，导致最终的‘完成’动画不会出现。只是一个小的bug。
